### PR TITLE
Add generic DbContextOptionsBuilder<TContext> and DbContextOptions<TContext> overloads

### DIFF
--- a/src/Pomelo.EntityFrameworkCore.Lolita.MySql/Extensions/LolitaDbOptionExtension.cs
+++ b/src/Pomelo.EntityFrameworkCore.Lolita.MySql/Extensions/LolitaDbOptionExtension.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore.Infrastructure;
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 using Pomelo.EntityFrameworkCore.Lolita.Update;
 using Pomelo.EntityFrameworkCore.Lolita.Delete;
@@ -23,7 +24,21 @@ namespace Microsoft.EntityFrameworkCore
             return self;
         }
 
+        public static DbContextOptionsBuilder<TContext> UseMySqlLolita<TContext>(this DbContextOptionsBuilder<TContext> self) where TContext : DbContext
+        {
+            ((IDbContextOptionsBuilderInfrastructure)self).AddOrUpdateExtension(new LolitaDbOptionExtension());
+            ((IDbContextOptionsBuilderInfrastructure)self).AddOrUpdateExtension(new MySqlLolitaDbOptionExtension());
+            return self;
+        }
+
         public static DbContextOptions UseMySqlLolita(this DbContextOptions self)
+        {
+            ((IDbContextOptionsBuilderInfrastructure)self).AddOrUpdateExtension(new LolitaDbOptionExtension());
+            ((IDbContextOptionsBuilderInfrastructure)self).AddOrUpdateExtension(new MySqlLolitaDbOptionExtension());
+            return self;
+        }
+
+        public static DbContextOptions<TContext> UseMySqlLolita<TContext>(this DbContextOptions<TContext> self) where TContext : DbContext
         {
             ((IDbContextOptionsBuilderInfrastructure)self).AddOrUpdateExtension(new LolitaDbOptionExtension());
             ((IDbContextOptionsBuilderInfrastructure)self).AddOrUpdateExtension(new MySqlLolitaDbOptionExtension());

--- a/src/Pomelo.EntityFrameworkCore.Lolita.PostgreSQL/Extensions/LolitaDbOptionExtension.cs
+++ b/src/Pomelo.EntityFrameworkCore.Lolita.PostgreSQL/Extensions/LolitaDbOptionExtension.cs
@@ -23,7 +23,21 @@ namespace Microsoft.EntityFrameworkCore
             return self;
         }
 
+        public static DbContextOptionsBuilder<TContext> UsePostgreSQLLolita<TContext>(this DbContextOptionsBuilder<TContext> self) where TContext : DbContext
+        {
+            ((IDbContextOptionsBuilderInfrastructure)self).AddOrUpdateExtension(new LolitaDbOptionExtension());
+            ((IDbContextOptionsBuilderInfrastructure)self).AddOrUpdateExtension(new PostgreSQLLolitaDbOptionExtension());
+            return self;
+        }
+
         public static DbContextOptions UsePostgreSQLLolita(this DbContextOptions self)
+        {
+            ((IDbContextOptionsBuilderInfrastructure)self).AddOrUpdateExtension(new LolitaDbOptionExtension());
+            ((IDbContextOptionsBuilderInfrastructure)self).AddOrUpdateExtension(new PostgreSQLLolitaDbOptionExtension());
+            return self;
+        }
+
+        public static DbContextOptions<TContext> UsePostgreSQLLolita<TContext>(this DbContextOptions<TContext> self) where TContext : DbContext
         {
             ((IDbContextOptionsBuilderInfrastructure)self).AddOrUpdateExtension(new LolitaDbOptionExtension());
             ((IDbContextOptionsBuilderInfrastructure)self).AddOrUpdateExtension(new PostgreSQLLolitaDbOptionExtension());

--- a/src/Pomelo.EntityFrameworkCore.Lolita.SqlServer/Extensions/LolitaDbOptionExtension.cs
+++ b/src/Pomelo.EntityFrameworkCore.Lolita.SqlServer/Extensions/LolitaDbOptionExtension.cs
@@ -23,7 +23,21 @@ namespace Microsoft.EntityFrameworkCore
             return self;
         }
 
+        public static DbContextOptionsBuilder<TContext> UseSqlServerLolita<TContext>(this DbContextOptionsBuilder<TContext> self) where TContext : DbContext
+        {
+            ((IDbContextOptionsBuilderInfrastructure)self).AddOrUpdateExtension(new LolitaDbOptionExtension());
+            ((IDbContextOptionsBuilderInfrastructure)self).AddOrUpdateExtension(new SqlServerLolitaDbOptionExtension());
+            return self;
+        }
+
         public static DbContextOptions UseSqlServerLolita(this DbContextOptions self)
+        {
+            ((IDbContextOptionsBuilderInfrastructure)self).AddOrUpdateExtension(new LolitaDbOptionExtension());
+            ((IDbContextOptionsBuilderInfrastructure)self).AddOrUpdateExtension(new SqlServerLolitaDbOptionExtension());
+            return self;
+        }
+
+        public static DbContextOptions<TContext> UseSqlServerLolita<TContext>(this DbContextOptions<TContext> self) where TContext : DbContext
         {
             ((IDbContextOptionsBuilderInfrastructure)self).AddOrUpdateExtension(new LolitaDbOptionExtension());
             ((IDbContextOptionsBuilderInfrastructure)self).AddOrUpdateExtension(new SqlServerLolitaDbOptionExtension());

--- a/src/Pomelo.EntityFrameworkCore.Lolita.Sqlite/Extensions/LolitaDbOptionExtension.cs
+++ b/src/Pomelo.EntityFrameworkCore.Lolita.Sqlite/Extensions/LolitaDbOptionExtension.cs
@@ -23,7 +23,21 @@ namespace Microsoft.EntityFrameworkCore
             return self;
         }
 
+        public static DbContextOptionsBuilder<TContext> UseSqliteLolita<TContext>(this DbContextOptionsBuilder<TContext> self) where TContext : DbContext
+        {
+            ((IDbContextOptionsBuilderInfrastructure)self).AddOrUpdateExtension(new LolitaDbOptionExtension());
+            ((IDbContextOptionsBuilderInfrastructure)self).AddOrUpdateExtension(new SqliteLolitaDbOptionExtension());
+            return self;
+        }
+
         public static DbContextOptions UseSqliteLolita(this DbContextOptions self)
+        {
+            ((IDbContextOptionsBuilderInfrastructure)self).AddOrUpdateExtension(new LolitaDbOptionExtension());
+            ((IDbContextOptionsBuilderInfrastructure)self).AddOrUpdateExtension(new SqliteLolitaDbOptionExtension());
+            return self;
+        }
+
+        public static DbContextOptions<TContext> UseSqliteLolita<TContext>(this DbContextOptions<TContext> self) where TContext : DbContext
         {
             ((IDbContextOptionsBuilderInfrastructure)self).AddOrUpdateExtension(new LolitaDbOptionExtension());
             ((IDbContextOptionsBuilderInfrastructure)self).AddOrUpdateExtension(new SqliteLolitaDbOptionExtension());

--- a/src/Pomelo.EntityFrameworkCore.Lolita/Extensions/LolitaDbOptionExtension.cs
+++ b/src/Pomelo.EntityFrameworkCore.Lolita/Extensions/LolitaDbOptionExtension.cs
@@ -25,7 +25,19 @@ namespace Microsoft.EntityFrameworkCore
             return self;
         }
 
+        public static DbContextOptionsBuilder<TContext> UseLolita<TContext>(this DbContextOptionsBuilder<TContext> self) where TContext : DbContext
+        {
+            ((IDbContextOptionsBuilderInfrastructure)self).AddOrUpdateExtension(new LolitaDbOptionExtension());
+            return self;
+        }
+
         public static DbContextOptions UseLolita(this DbContextOptions self)
+        {
+            ((IDbContextOptionsBuilderInfrastructure)self).AddOrUpdateExtension(new LolitaDbOptionExtension());
+            return self;
+        }
+
+        public static DbContextOptions<TContext> UseLolita<TContext>(this DbContextOptions<TContext> self) where TContext : DbContext
         {
             ((IDbContextOptionsBuilderInfrastructure)self).AddOrUpdateExtension(new LolitaDbOptionExtension());
             return self;


### PR DESCRIPTION
At the moment, if I do this:

```csharp
var databaseOptionsBuilder = new DbContextOptionsBuilder<DataContext>()
    .UseMySql("server=localhost;database=lolita;uid=root;pwd=yourpwd;")
    .UseMySqlLolita();
```

the `databaseOptionsBuilder` 's type will be `DbContextOptionsBuilder` (without the generic `<DataContext>` type). This PR fixes that.